### PR TITLE
chore: sync .github with latest template.jl + Registrator guideline fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: 🐛 Bug Report
+description: バグや問題を報告する
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグ報告ありがとうございます。以下の情報を提供してください。
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What kind of issue are you experiencing?
+      placeholder: Please describe the bug in detail.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Codes to Reproduce
+      description: Provide a code snippet that reproduces the issue.
+      placeholder: |
+        ```julia
+        # paste your code
+        ```
+      render: julia
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Version of Julia etc...
+      placeholder: |
+        - Julia version: 
+        - OS:
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      description: If there is any other information that may be helpful, please provide it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/sotashimozono/template.jl/discussions
+    about: Use `Discussions` for questions and general discussions

--- a/.github/ISSUE_TEMPLATE/wishlist.yml
+++ b/.github/ISSUE_TEMPLATE/wishlist.yml
@@ -1,0 +1,62 @@
+name: 💭 Wish List
+description: Ideas for future features and improvements
+title: "[Wish]: "
+labels: ["wishlist", "future"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Record ideas for features or improvements to be implemented in the future.
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: Feature Idea
+      description: What feature or functionality would you like to implement?
+      placeholder: Describe your idea in detail...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How would you prioritize this feature?
+      options:
+        - "High - Immediate priority / Urgent"
+        - "Medium - Planned for future development"
+        - "Low - Long-term idea / Just a note"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context & Rationale
+      description: Why is this feature needed? (e.g., scientific motivation, workflow efficiency)
+    validations:
+      required: false
+
+  - type: textarea
+    id: sketch
+    attributes:
+      label: Sketch & Conceptual Design
+      description: Describe implementation ideas or technical approaches.
+      placeholder: |
+        ```julia
+        # Conceptual implementation or pseudo-code
+        function solve_new_method(params...)
+            # ...
+        end
+        ```
+      render: julia
+    validations: 
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Related papers, links, other libraries, or prior discussions.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+The two sections "Proposed Changes" and "Usage or Results" below are
+extracted by .github/scripts/build_release_notes.py and inserted into
+the GitHub Release notes when a new tag is published. Treat them as the
+PR's contribution to the changelog: keep them readable, focused, and
+self-contained. Renaming or removing those headings will break the
+release-notes builder.
+-->
+
+## Description
+
+Fixed: #  (if any)
+
+## Type of Change
+
+- [ ] ✨ **Feature** (`enhancement`)
+- [ ] 🐛 **Bug Fix** (`bug`)
+- [ ] ⚡ **Performance** (`performance`)
+- [ ] 📖 **Documentation** (`documentation`)
+- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
+- [ ] 💥 **Breaking change** (`breaking`) — forces a minor bump and a
+  `## Breaking changes` section in the drafted release notes. Tick this
+  whenever you rename / remove public API, change field layouts, or
+  otherwise require a downstream code change.
+
+## Proposed Changes
+
+<!-- This section is included in the release notes. -->
+
+what did you change?
+
+- write here
+
+## Usage or Results
+
+<!-- This section is included in the release notes. -->
+
+```julia
+# Example or verification script
+
+```
+
+## check list
+- [ ] test駆動をしたか
+- [ ] Project.tomlのバージョンを上げたか

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,39 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels: ['major']
+  minor:
+    labels:
+      - 'minor'
+      - 'breaking'
+  patch:
+    labels: ['patch']
+  default: patch
+categories:
+  - title: '💥 Breaking changes'
+    labels:
+      - 'breaking'
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+      - 'feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: '⚡ Performance'
+    labels:
+      - 'performance'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'refactor'
+
+template: |
+  ## Changelog
+
+  $CHANGES

--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -1,0 +1,33 @@
+{
+  "name": "Main Branch Protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_signatures" },
+    { "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    { "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "build" } 
+        ]
+      }
+    }
+  ]
+}

--- a/.github/scripts/build_release_notes.py
+++ b/.github/scripts/build_release_notes.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Build rich GitHub release notes from merged pull requests.
+
+For each merged PR since the previous tag we extract the
+``## Proposed Changes`` and ``## Usage or Results`` sections from the
+PR body (matching the wording of `.github/PULL_REQUEST_TEMPLATE.md`)
+and group them under category headings determined by labels.
+
+Output is markdown printed to stdout, suitable to feed into
+
+    gh release create "$TAG" --notes-file -
+or
+    gh release edit "$TAG" --notes-file release-notes.md --draft=false
+
+Requires:
+    - python 3.9+
+    - `gh` CLI authenticated (set GH_TOKEN in CI)
+    - run from inside a git checkout with `fetch-depth: 0`
+
+Inputs (CLI):
+    --tag TAG         the tag being published (e.g. v0.3.0). Required.
+    --previous TAG    previous tag to diff against. Auto-detected if omitted.
+    --repo OWNER/REPO defaults to env GITHUB_REPOSITORY.
+
+Stability contract:
+    The PR template's section headings (`## Proposed Changes` and
+    `## Usage or Results`) are an implicit input to this script.
+    If the template is renamed, update SECTIONS below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+
+# ---------------------------------------------------------------------
+#  Configuration
+# ---------------------------------------------------------------------
+
+# Categories for grouping. Order matters — labels are matched in this
+# order, and a PR is placed in the FIRST category whose label set
+# contains one of the listed labels. PRs with no matching label fall
+# into UNCATEGORISED.
+CATEGORIES = [
+    ("⚠️ Breaking Changes", ["breaking"]),
+    ("🚀 Features",          ["enhancement", "feature"]),
+    ("🐛 Bug Fixes",         ["bug", "fix"]),
+    ("⚡ Performance",       ["performance"]),
+    ("📖 Documentation",     ["documentation", "docs"]),
+    ("🧰 Maintenance",       ["chore", "refactor", "ci"]),
+]
+UNCATEGORISED = "🔧 Other Changes"
+
+# Labels that exclude a PR from the release notes entirely.
+EXCLUDE_LABELS = {"skip-changelog", "wontfix", "duplicate", "invalid"}
+
+# Section headers we extract from each PR body. Each tuple is:
+#     (header in PR template, display label in release notes)
+SECTIONS = [
+    ("Proposed Changes", "What changed"),
+    ("Usage or Results", "How to use"),
+]
+
+
+# ---------------------------------------------------------------------
+#  Subprocess helpers
+# ---------------------------------------------------------------------
+
+def gh(*args: str) -> str:
+    """Run `gh <args...>` and return stdout. Raises on non-zero."""
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+def gh_json(*args: str):
+    return json.loads(gh(*args))
+
+
+def git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+# ---------------------------------------------------------------------
+#  Tag / PR discovery
+# ---------------------------------------------------------------------
+
+def find_previous_tag(current_tag: str) -> Optional[str]:
+    """Return the most recent tag before *current_tag* (by creator date)."""
+    try:
+        tags = git("tag", "--sort=-creatordate").splitlines()
+    except subprocess.CalledProcessError:
+        return None
+    for t in tags:
+        if t and t != current_tag:
+            return t
+    return None
+
+
+def merged_prs_since(repo: str, previous_tag: Optional[str]):
+    """Return a list of PR dicts merged since *previous_tag*'s commit date.
+
+    If *previous_tag* is None this returns all merged PRs (used for the
+    very first release).
+    """
+    search = "is:merged"
+    if previous_tag:
+        try:
+            prev_date = git("log", "-1", "--format=%aI", previous_tag)
+            search = f"merged:>{prev_date}"
+        except subprocess.CalledProcessError:
+            pass
+
+    return gh_json(
+        "pr", "list",
+        "--repo", repo,
+        "--state", "merged",
+        "--base", "main",
+        "--limit", "200",
+        "--search", search,
+        "--json", "number,title,author,body,labels,url,mergedAt",
+    )
+
+
+# ---------------------------------------------------------------------
+#  Section extraction
+# ---------------------------------------------------------------------
+
+# Phrases that indicate a section was left at its template default.
+PLACEHOLDER_PHRASES = [
+    r"what did you change\??",
+    r"-\s*write here",
+    r"#\s*Example or verification script",
+    r"_no description provided\._",
+    r"placeholder",
+]
+
+PLACEHOLDER_RE = re.compile("|".join(PLACEHOLDER_PHRASES), re.IGNORECASE)
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def strip_decoration(text: str) -> str:
+    """Remove HTML comments and surrounding whitespace from `text`."""
+    text = HTML_COMMENT_RE.sub("", text)
+    return text.strip()
+
+
+def is_meaningful(text: str) -> bool:
+    """Return True if `text` looks like real content rather than placeholder.
+
+    Strips HTML comments, code-fence markers and known placeholder
+    phrases, then checks that something other than whitespace remains.
+    """
+    cleaned = HTML_COMMENT_RE.sub("", text)
+    cleaned = re.sub(r"^```\w*$|^```$", "", cleaned, flags=re.MULTILINE)
+    cleaned = PLACEHOLDER_RE.sub("", cleaned)
+    return bool(cleaned.strip())
+
+
+def extract_section(body: str, header: str) -> str:
+    """Extract the body of `## <header>` until the next `## ` heading.
+
+    Returns an empty string if the section is missing or contains only
+    placeholder content. HTML comments inside the section are stripped
+    so template hint comments do not leak into release notes.
+    """
+    if not body:
+        return ""
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
+    pattern = re.compile(
+        r"^##\s+" + re.escape(header) + r"\s*\n(.*?)(?=^##\s|\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    m = pattern.search(body)
+    if not m:
+        return ""
+    text = m.group(1)
+    if not is_meaningful(text):
+        return ""
+    return strip_decoration(text)
+
+
+# ---------------------------------------------------------------------
+#  Categorisation + rendering
+# ---------------------------------------------------------------------
+
+def categorise(pr) -> str:
+    label_names = {l["name"].lower() for l in pr.get("labels", [])}
+    for title, labels in CATEGORIES:
+        if any(lab in label_names for lab in labels):
+            return title
+    return UNCATEGORISED
+
+
+def excluded(pr) -> bool:
+    label_names = {l["name"].lower() for l in pr.get("labels", [])}
+    return bool(label_names & EXCLUDE_LABELS)
+
+
+def render_pr(pr) -> str:
+    """Render one PR as a markdown sub-section."""
+    title = pr["title"]
+    number = pr["number"]
+    author = pr.get("author") or {}
+    login = author.get("login", "ghost")
+    url = pr["url"]
+    body = pr.get("body") or ""
+
+    lines = [f"### #{number} — {title} (@{login})", ""]
+
+    sections_present = False
+    for header, display in SECTIONS:
+        section = extract_section(body, header)
+        if not section:
+            continue
+        sections_present = True
+        # Use a collapsible details block so long Usage code blocks
+        # don't blow out the release notes view.
+        lines.append(f"<details><summary><b>{display}</b></summary>")
+        lines.append("")
+        lines.append(section)
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    if not sections_present:
+        lines.append(f"_No detailed notes provided. See {url}._")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_notes(repo: str, tag: str, previous: Optional[str]) -> str:
+    prs = [pr for pr in merged_prs_since(repo, previous) if not excluded(pr)]
+
+    out: list[str] = []
+    out.append(f"## What's Changed in {tag}")
+    out.append("")
+
+    if not prs:
+        out.append("_No merged pull requests in this release._")
+        out.append("")
+    else:
+        groups: dict[str, list] = {title: [] for title, _ in CATEGORIES}
+        groups[UNCATEGORISED] = []
+        for pr in prs:
+            groups[categorise(pr)].append(pr)
+
+        for title in [c[0] for c in CATEGORIES] + [UNCATEGORISED]:
+            items = groups.get(title) or []
+            if not items:
+                continue
+            out.append(f"## {title}")
+            out.append("")
+            for pr in items:
+                out.append(render_pr(pr))
+                out.append("")
+
+    if previous:
+        out.append(
+            f"**Full Changelog**: "
+            f"https://github.com/{repo}/compare/{previous}...{tag}"
+        )
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------
+#  Entrypoint
+# ---------------------------------------------------------------------
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--tag", required=True, help="tag being published, e.g. v0.3.0")
+    p.add_argument("--previous", default=None,
+                   help="previous tag (auto-detected if omitted)")
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"),
+                   help="owner/repo (defaults to GITHUB_REPOSITORY env var)")
+    args = p.parse_args()
+
+    if not args.repo:
+        sys.exit("error: --repo or GITHUB_REPOSITORY required")
+
+    previous = args.previous or find_previous_tag(args.tag)
+    print(build_notes(args.repo, args.tag, previous))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/AutoRegister.yml.disabled
+++ b/.github/workflows/AutoRegister.yml.disabled
@@ -1,0 +1,83 @@
+name: AutoRegister
+
+# Runs after Release Drafter completes on main.
+# If Project.toml version changed, posts @JuliaRegistrator register comment.
+
+on:
+  workflow_run:
+    workflows: ['Release Drafter']
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  register:
+    # Only run if Release Drafter succeeded
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2 # need HEAD and HEAD~1 to compare
+
+      - name: Check if version changed
+        id: version_check
+        run: |
+          PREV=$(git show HEAD~1:Project.toml 2>/dev/null | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/' || echo "")
+          CURR=$(grep '^version' Project.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "prev=$PREV"
+          echo "curr=$CURR"
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          echo "curr=$CURR" >> "$GITHUB_OUTPUT"
+          if [ "$PREV" != "$CURR" ] && [ -n "$CURR" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release notes text
+        if: steps.version_check.outputs.changed == 'true'
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURR: ${{ steps.version_check.outputs.curr }}
+        run: |
+          DRAFT_BODY=$(gh release list --limit 50 --json tagName,isDraft \
+            --jq '.[] | select(.isDraft == true) | .tagName' | head -n 1 | \
+            xargs -I{} gh release view {} --json body --jq '.body' 2>/dev/null || echo "")
+
+          if [ -z "$DRAFT_BODY" ] || [ "$DRAFT_BODY" = "null" ]; then
+            DRAFT_BODY="- See commit history for details in v${CURR}."
+          fi
+
+          # Always wrap the body with a '## Changelog' header so the
+          # registered comment contains the literal 'changelog' keyword
+          # that Registrator's guideline checks for (required on any
+          # breaking release, harmless otherwise). If the upstream draft
+          # already carries its own header the nesting is cosmetic only.
+          WRAPPED=$(printf '## Changelog\n\n%s\n\nSee the full changelog at <https://github.com/%s/releases/tag/v%s>.' \
+            "$DRAFT_BODY" "${{ github.repository }}" "$CURR")
+
+          printf 'content<<RELEASE_NOTES_EOF\n%s\nRELEASE_NOTES_EOF\n' "$WRAPPED" >> "$GITHUB_OUTPUT"
+
+      - name: Post @JuliaRegistrator comment on commit
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.content }}
+          CURR: ${{ steps.version_check.outputs.curr }}
+          PREV: ${{ steps.version_check.outputs.prev }}
+          COMMIT: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          BODY=$(printf '@JuliaRegistrator register\n\nRelease notes:\n\n%s\n\nVersion bumped from `%s` -> `%s` by commit %s.' \
+            "$RELEASE_NOTES" "$PREV" "$CURR" "$COMMIT")
+
+          # Registrator accepts comments on commits, not pull requests.
+          gh api "repos/${REPO}/commits/${COMMIT}/comments" -f body="$BODY"

--- a/.github/workflows/PRLabeler.yml
+++ b/.github/workflows/PRLabeler.yml
@@ -1,0 +1,52 @@
+name: Checkbox Labeler
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+  issues: write          # required for gh label create
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Labels based on Checkboxes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Ensure all labels exist (--force updates color/description if already present)
+          gh label create "enhancement"   --repo "$REPO" --color "a2eeef" --force
+          gh label create "bug"           --repo "$REPO" --color "d73a4a" --force
+          gh label create "performance"   --repo "$REPO" --color "e4e669" --force
+          gh label create "documentation" --repo "$REPO" --color "0075ca" --force
+          gh label create "chore"         --repo "$REPO" --color "e8e8e8" --force
+          gh label create "breaking"      --repo "$REPO" --color "b60205" --force
+
+          if echo "$PR_BODY" | grep -qi "\- \[x\].*Feature"; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "enhancement"
+          fi
+
+          if echo "$PR_BODY" | grep -qi "\- \[x\].*Bug Fix"; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "bug"
+          fi
+
+          if echo "$PR_BODY" | grep -qi "\- \[x\].*Performance"; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "performance"
+          fi
+
+          if echo "$PR_BODY" | grep -qi "\- \[x\].*Documentation"; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "documentation"
+          fi
+
+          if echo "$PR_BODY" | grep -qi "\- \[x\].*Maintenance"; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "chore"
+          fi
+
+          if echo "$PR_BODY" | grep -qi "\- \[x\].*Breaking"; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "breaking"
+          fi

--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -1,0 +1,72 @@
+name: Publish Release
+
+# Publishes a GitHub Release whenever a vX.Y.Z tag is pushed.
+#
+# The release notes are built by `.github/scripts/build_release_notes.py`,
+# which inspects every PR merged since the previous tag, extracts the
+# `## Proposed Changes` and `## Usage or Results` sections from each PR
+# body, groups them by label, and writes a rich markdown report.
+#
+# If a draft release for this tag already exists (e.g. left by Release
+# Drafter) it is overwritten with the rich notes and published.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag to publish (e.g. v0.3.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history so the script can find the previous tag
+          # via `git tag --sort=-creatordate` and `git log <tag>`.
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/release
+          python3 .github/scripts/build_release_notes.py \
+            --tag "${{ steps.tag.outputs.tag }}" \
+            > /tmp/release/notes.md
+          echo "--- generated notes ---"
+          cat /tmp/release/notes.md
+          echo "-----------------------"
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --notes-file /tmp/release/notes.md \
+              --draft=false
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file /tmp/release/notes.md
+          fi

--- a/.github/workflows/VersionCheck.yml.disabled
+++ b/.github/workflows/VersionCheck.yml.disabled
@@ -1,0 +1,72 @@
+name: VersionCheck
+
+# Ensures that every PR targeting main bumps Project.toml version.
+# The check fails if the version in the PR branch is not strictly greater
+# than the version on the base branch.
+#
+# IMPORTANT: this workflow runs on *every* PR, not only PRs that touch
+# Project.toml. Restricting the trigger with `paths: Project.toml`
+# would let version-bump-forgotten PRs slip through silently because
+# the workflow would never run, and required-check gating treats the
+# absent run as a "skipped, OK" instead of a failure.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch both the PR branch and the base branch so we can compare.
+          fetch-depth: 0
+
+      - name: Get base branch version
+        id: base
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          VERSION=$(git show origin/${{ github.base_ref }}:Project.toml \
+            | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Base version: $VERSION"
+
+      - name: Get PR branch version
+        id: pr
+        run: |
+          VERSION=$(grep '^version' Project.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "PR version: $VERSION"
+
+      - name: Compare versions (semver)
+        env:
+          BASE: ${{ steps.base.outputs.version }}
+          PR:   ${{ steps.pr.outputs.version }}
+        run: |
+          # Split a semver string into its numeric parts and compare.
+          version_gt() {
+            # Returns 0 (success) if $1 > $2 as semver, 1 otherwise.
+            IFS='.' read -r -a A <<< "$1"
+            IFS='.' read -r -a B <<< "$2"
+            for i in 0 1 2; do
+              a="${A[$i]:-0}"
+              b="${B[$i]:-0}"
+              if [ "$a" -gt "$b" ]; then return 0; fi
+              if [ "$a" -lt "$b" ]; then return 1; fi
+            done
+            return 1  # equal is not greater
+          }
+
+          echo "Base: $BASE  →  PR: $PR"
+          if version_gt "$PR" "$BASE"; then
+            echo "✓ Version bumped ($BASE → $PR)"
+          else
+            echo "✗ Version NOT bumped. PR version ($PR) must be strictly greater than base version ($BASE)."
+            exit 1
+          fi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        with:
+          commitish: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This repo was one of two ([LSystems.jl](https://github.com/sotashimozono/LSystems.jl), [FibonacciRG.jl](https://github.com/sotashimozono/FibonacciRG.jl)) that hadn't yet picked up the newer pieces of the shared `sotashimozono/template.jl` layout. This PR brings its `.github/` tree into line with the current template, so it participates in the same release-drafting / labeling / registration flow as every other package in the fleet.

### Files copied in from `template.jl`

- `release-drafter.yml` (config) + `workflows/release-drafter.yml` (the workflow itself)
- `workflows/PRLabeler.yml` — auto-label PRs from the *Type of Change* checkboxes
- `workflows/AutoRegister.yml.disabled` — kept disabled; posts `@JuliaRegistrator register` after a version bump once enabled
- `workflows/PublishRelease.yml` — publishes a GitHub Release on tag push
- `workflows/VersionCheck.yml.disabled` — kept disabled; guards against accidental version bumps without changelog
- `PULL_REQUEST_TEMPLATE.md` — the shared template with a checkbox-driven *Type of Change* and release-notes-friendly *Proposed Changes* / *Usage or Results* sections
- `ISSUE_TEMPLATE/*` (bug_report / wishlist / config) if missing
- `scripts/build_release_notes.py` — extracts *Proposed Changes* / *Usage or Results* from merged PRs into release notes
- `rulesets/main-protection.json` — main branch protection ruleset

Deliberately **not** copied (bootstrap-only or intentionally absent):
- `workflows/init.yml` (first-run rename+UUID bootstrap; only runs on a fresh fork)
- `workflows/docker-publish.yml` (Julia package, no docker image)
- `scripts/setup_project.jl` (bootstrap script)
- Anything that already exists in this repo in either enabled or `.disabled` form (user's choice is preserved).

### Registrator guideline fix applied at the same time

The same patch as the fleet-wide `chore: satisfy Registrator AutoMerge guidelines automatically` PRs is applied on top of the copied files, so:
- `release-drafter.yml` has a `💥 Breaking changes` category and the `breaking` label triggers a minor bump.
- `PRLabeler.yml` auto-applies the `breaking` label when the checkbox is ticked.
- `PULL_REQUEST_TEMPLATE.md` has the *Breaking change* checkbox.
- `AutoRegister.yml.disabled` wraps drafted release notes with `## Changelog` before posting to `@JuliaRegistrator`, so Registrator's required `breaking` / `changelog` keyword is always present when it's eventually enabled.

## Test plan
- [ ] `release-drafter` workflow runs successfully on next PR merge.
- [ ] `PRLabeler` labels this PR from its checkboxes.
- [ ] The `breaking` label gets created on first use.

## Type of Change

- [ ] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [x] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)