### PR TITLE
chore: address review feedback on registry-guideline automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Fixed: #  (if any)
 - [ ] 📖 **Documentation** (`documentation`)
 - [ ] 🧰 **Maintenance** (`chore` or `refactor`)
 - [ ] 💥 **Breaking change** (`breaking`) — forces a minor bump and a
-  `## Breaking changes` section in the drafted release notes. Tick this
+  breaking-changes section in the drafted release notes. Tick this
   whenever you rename / remove public API, change field layouts, or
   otherwise require a downstream code change.
 

--- a/.github/workflows/AutoRegister.yml.disabled
+++ b/.github/workflows/AutoRegister.yml.disabled
@@ -63,8 +63,12 @@ jobs:
           # already carries its own header the nesting is cosmetic only.
           WRAPPED=$(printf '## Changelog\n\n%s\n\nSee the full changelog at <https://github.com/%s/releases/tag/v%s>.' \
             "$DRAFT_BODY" "${{ github.repository }}" "$CURR")
-
-          printf 'content<<RELEASE_NOTES_EOF\n%s\nRELEASE_NOTES_EOF\n' "$WRAPPED" >> "$GITHUB_OUTPUT"
+          delim="RELEASE_NOTES_$(openssl rand -hex 16)"
+          {
+            echo "content<<$delim"
+            printf '%s\n' "$WRAPPED"
+            echo "$delim"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post @JuliaRegistrator comment on commit
         if: steps.version_check.outputs.changed == 'true'

--- a/.github/workflows/PRLabeler.yml
+++ b/.github/workflows/PRLabeler.yml
@@ -49,4 +49,6 @@ jobs:
 
           if echo "$PR_BODY" | grep -qi "\- \[x\].*Breaking"; then
             gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "breaking"
+          else
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "breaking" 2>/dev/null || true
           fi


### PR DESCRIPTION
## Summary

Addresses review feedback on the registry-guideline automation PR that already merged into this repo (sibling of sotashimozono/Lattice2D.jl#23 / #35 on QAtlas). Three small fixes, all localised to `.github/`:

### 1. PRLabeler: the `breaking` label no longer sticks

Previously PRLabeler only ever *added* the `breaking` label based on the Type-of-Change checkbox. If a contributor checked the box, saved the PR body, and then unchecked it, the label remained — and since release-drafter uses `breaking` to force a minor bump, that stale label could silently promote a patch release into a minor one.

The workflow now toggles both directions: when the checkbox is unticked (or absent), it runs `gh pr edit ... --remove-label breaking` (error-tolerant, so it's a no-op when the label was never applied).

### 2. AutoRegister: unique `$GITHUB_OUTPUT` heredoc delimiter

The `Generate release notes text` step used a fixed `RELEASE_NOTES_EOF` delimiter when writing the wrapped body to `$GITHUB_OUTPUT`. The drafted release body is effectively user-controlled — a draft that happens to contain a line literally equal to `RELEASE_NOTES_EOF` would truncate the output and corrupt the `@JuliaRegistrator register` comment body.

Replaced with a random delimiter per run:

```bash
delim="RELEASE_NOTES_$(openssl rand -hex 16)"
{
  echo "content<<$delim"
  printf '%s\n' "$WRAPPED"
  echo "$delim"
} >> "$GITHUB_OUTPUT"
```

### 3. PR template: generic "breaking-changes section" wording

The checkbox description previously promised a `` `## Breaking changes` `` section in the drafted release notes. release-drafter's actual category titles vary across the fleet (`💥 Breaking changes` / `⚠️ Breaking Changes`), so the exact header string was never guaranteed. Reworded to the generic "breaking-changes section" — same meaning, no false promise.

## Test plan
- [ ] Tick and untick the *Breaking change* checkbox on a throwaway PR → label appears / disappears.
- [ ] Next time `AutoRegister` fires, the posted Registrator comment body is intact even for multi-line drafts.

## Type of Change

- [ ] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [x] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)