### PR TITLE
ci: track the hub's main instead of the @v1 tag

### DIFF
--- a/.github/workflows/PRLabeler.yml
+++ b/.github/workflows/PRLabeler.yml
@@ -12,4 +12,4 @@ permissions:
   issues: write            # addLabels / createLabel are issue-scoped, even on a PR
 jobs:
   label:
-    uses: QAtlasHub/.github/.github/workflows/labeler.yml@v1
+    uses: QAtlasHub/.github/.github/workflows/labeler.yml@main

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LSystems"
 uuid = "a3e1f8ee-70d8-4c26-a6f5-dc669742461a"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["sota <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
Every caller of the QAtlasHub hub references `@v1`. `v1` is a **moving tag** currently at `v1.0.3`,
so it is not a rotting pin — but it is a second pointer that has to be pushed by hand, and it is one
release behind `main` right now, which is exactly the failure it invites: a fix merges and reaches
nobody.

## Measured, 2026-07-30

241 reusable references across the three owners:

| hub | ref | count |
|---|---|---|
| `lab-sotashimozono` | `@main` | 166 |
| `QAtlasHub` | `@v1` | **65** |
| `QAtlasHub` | `@main` | 10 |

Those 10 are not callers — they are the `uses:` examples inside the reusables' own header comments,
which already say `@main`. So **the hub documents `@main` and every real caller uses `@v1`.** The lab
hub has no `@v1` references at all; this brings the two owners onto one convention.

## Blast radius, exactly

`QAtlasHub/.github` `main` is `v1` plus **one commit**:

```
+84/-0  .github/workflows/julia-ci.yml   (QAtlasHub/.github#20)
```

Purely additive — the `julia-ci` timings producer, gated on `shards > 1` **and** `push:main`, with the
recording job `continue-on-error`. Nothing else differs, so this switch delivers exactly that and
nothing more.

It also makes that fix testable: `record-timings` only runs on `push:main`, so no PR anywhere could
exercise it (QAtlasHub/.github#19). A `shards: 4` caller on `@main` is the first real check.

## Why `@main` rather than moving `v1`

Moving the tag on every merge makes `v1` an alias for `main` with extra machinery and one more thing
to forget. `main` is gated by the hub's own `actionlint`, and the standing rule is to track latest
rather than pin. After this the tag is unreferenced and can be retired separately.

Refs lab-sotashimozono/.github#15