### PR TITLE
Split the test suite, through TestShards.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,35 +1,36 @@
 name: CI
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     tags: '*'
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# This suite was not split before. The whole sharded-test vertical is QAtlasHub/TestShards.jl:
+# nothing is planned up front — each shard decides what it owns from the same timing history —
+# and the reusable merges the shards' coverage into one Codecov upload, merges their records into
+# one ordered document, checks that every unit ran exactly once, and refreshes `ci-timings` on
+# pushes to main.
+#
+# The split is not the only thing gained. The exactly-once check and the merged record hold for a
+# small suite too, and with no history the first run is round-robin and balances itself from the
+# second push onward.
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      # ▼ ここがJulia用のCodecov連携部分です ▼
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v7
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+    permissions:
+      contents: write   # the timing history is pushed to the `ci-timings` orphan branch
+    uses: QAtlasHub/TestShards.jl/.github/workflows/sharded-tests.yml@main
+    with:
+      # A starting point. The diagnosis printed on every run names the knee for THIS suite —
+      # read it and set what it says rather than keeping this number out of inertia.
+      shards: 2
+      # Also refreshes: a registry present but stale resolves fine while failing to see anything
+      # published since it was last pulled.
+      registries: |
+        General
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LSystems"
 uuid = "a3e1f8ee-70d8-4c26-a6f5-dc669742461a"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["sota <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -10,6 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+TestShards = "0.3"
 JSON3 = "1.14.3"
 LinearAlgebra = "1.12.0"
 SparseArrays = "1.12.0"
@@ -17,6 +18,7 @@ StaticArrays = "1.9.16"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestShards = "acceef1d-f5e0-4fe4-a546-818dc56ce7b2"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TestShards"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,27 @@
 ENV["GKSwstype"] = "100"
 
 using LSystems, Test
-const dirs = ["core"]
+using TestShards
 
-const FIG_BASE = joinpath(pkgdir(LSystems), "docs", "src", "assets", "figures")
-const PATHS = Dict()
-mkpath.(values(PATHS))
-
-@testset "tests" begin
-    test_args = copy(ARGS)
-    println("Passed arguments ARGS = $(test_args) to tests.")
-    @time for dir in dirs
-        dirpath = joinpath(@__DIR__, dir)
-        println("\nTest $(dirpath)")
-        files = sort(
-            filter(f -> startswith(f, "test_") && endswith(f, ".jl"), readdir(dirpath))
-        )
-        if isempty(files)
-            println("  No test files found in $(dirpath).")
-        else
-            for f in files
-                filepath = joinpath(dirpath, f)
-                @time begin
-                    println("  Including $(filepath)")
-                    include(filepath)
-                end
-            end
+# Every `test_*.jl` under `test/`, in a deterministic order, each one its own shardable unit.
+# `@shard` shadows `include` inside the block, so a unit is whatever this loop includes — a new
+# file, or a whole new directory, is picked up BY BEING ON DISK, rather than by being added to
+# the `dirs` list that used to sit here and could disagree with the tree.
+#
+# Two rules when adding to this, and they are the only two:
+#
+#   1. SHARED FIXTURES GO ABOVE THIS BLOCK. A helper included inside becomes a unit of its own,
+#      lands on ONE shard, and every test file on the other shards that needed it fails.
+#   2. ANYTHING THAT IS NOT A `test_*.jl` FILE MUST BE NAMED. The glob does not error on what it
+#      does not match; it silently stops running it.
+#
+# A bare `Pkg.test()` with nothing set in the environment runs all of it, in this order. Run one
+# shard locally with `TESTSHARDS_ID=s2 TESTSHARDS_N=2 julia --project -e 'using Pkg; Pkg.test()'`.
+TestShards.@shard begin
+    for (dir, _, files) in sort!(collect(walkdir(@__DIR__)))
+        for f in sort(files)
+            startswith(f, "test_") && endswith(f, ".jl") || continue
+            include(joinpath(dir, f))
         end
     end
 end


### PR DESCRIPTION
This suite ran as **one job**. It is now 4 units, split 2 ways by measured per-unit runtime.

`runtests.jl` globs `test_*.jl` under `test/` and includes each one, so a new file or a whole new directory is picked up **by being on disk** rather than by being added to a list that could disagree with the tree.

## The split is not the only thing gained

At this size it may not even be the main one. The reusable also:

- checks that **every unit ran exactly once** — a claim no unsharded run has to make, and none was making;
- merges the shards' coverage into **one** Codecov upload;
- merges their records into one ordered document.

With no timing history the first run is round-robin and balances itself from the second push onward.

`shards: 2` is a starting point — the diagnosis printed on every run names the knee for *this* suite.

Refs QAtlasHub/TestShards.jl#13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)